### PR TITLE
PUT request needs to convert cursor to array

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -190,7 +190,7 @@ export default class DataServer extends Componentry.Module {
         }
         let result = await this.connector.db.collection(collection).bulkWrite(writes);
         if (returnNewDocument && body[0]) {
-            return await this.connector.db.collection(collection).find(body[0]._id)
+            return await this.connector.db.collection(collection).findOne({_id: body[0]._id});
         } else {
             return {upsertedCount:result.upsertedCount,modifiedCount:result.modifiedCount};
         }

--- a/index.mjs
+++ b/index.mjs
@@ -190,7 +190,10 @@ export default class DataServer extends Componentry.Module {
         }
         let result = await this.connector.db.collection(collection).bulkWrite(writes);
         if (returnNewDocument && body[0]) {
-            return await this.connector.db.collection(collection).findOne({_id: body[0]._id});
+            const results = await this.connector.db.collection(collection)
+                .find({_id: body[0]._id}).toArray();
+            return results[0];
+        }
         } else {
             return {upsertedCount:result.upsertedCount,modifiedCount:result.modifiedCount};
         }


### PR DESCRIPTION
When using find, put was returning a MongoDB cursor, which contains circular references and cannot be serialized to JSON. findOne() returns a plain object, which can be sent safely.